### PR TITLE
Improvement for Jenkins ZWSP character

### DIFF
--- a/chrome-ext/background.js
+++ b/chrome-ext/background.js
@@ -5,7 +5,7 @@ async function injectCss(tabId, file) {
 }
 
 async function injectJs(tabId, file, cb) {
-	await chrome.scripting.executeScript({target: {tabId}, files: [file]}, () => {cb();});
+	await chrome.scripting.executeScript({target: {tabId}, files: [file]}, () => { if(cb) { cb(); } });
 }
 
 async function onInjectsDone(tabId) {
@@ -42,6 +42,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 		if (changeInfo.status === 'complete' && urlPattern && (new RegExp(urlPattern)).test(tab.url)) {
 			(async () => {
 				await injectCss(tabId, '/content/jenkins-ext-style.css');
+				await injectJs(tabId, '/content/jenkins-ext-zwsp-fixer.js');
 				await injectJs(tabId, '/common/common.js');
 				await injectJs(tabId, '/content/jenkins-ext-common.js');
 				await injectJs(tabId, '/content/jenkins-ext-commits.js');

--- a/chrome-ext/content/jenkins-ext-content.js
+++ b/chrome-ext/content/jenkins-ext-content.js
@@ -97,6 +97,7 @@ chrome.runtime.onMessage.addListener(request => {
 		const baseLocation = document.location.href.replace(/\?\S*/, '');
 		fetchCache = {};
 		linesCache = {};
+		cleanupZwsInsertedElements();
 		(async () => {
 			const json = await goFetchJson(baseLocation + 'api/json');
 			await onGetRootJobInfoDone(json);

--- a/chrome-ext/content/jenkins-ext-zwsp-fixer.js
+++ b/chrome-ext/content/jenkins-ext-zwsp-fixer.js
@@ -1,0 +1,9 @@
+function cleanupZwsInsertedElements() {
+    const zwsInsertedDomElms = document.querySelectorAll('.zws-inserted');
+    console.log(zwsInsertedDomElms);
+    if (zwsInsertedDomElms && zwsInsertedDomElms.length > 0) {
+        zwsInsertedDomElms.forEach(zwsInsertedDomElm => {
+            zwsInsertedDomElm.innerText = zwsInsertedDomElm.innerText.replace(/[\u200B]/g, '').trim();
+        });
+    }
+}

--- a/chrome-ext/manifest.json
+++ b/chrome-ext/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "2.0.1",
+  "version": "2.0.2",
   "name": "Jenkins Chrome Extension",
   "short_name": "JenkinsExt",
   "description": "Jenkins Chrome Extension",


### PR DESCRIPTION
1. Added new functionality to remove \u200B character from any element with .zws-inserted class which has innerText containing it. This is related to Jenkins bug: https://issues.jenkins.io/browse/JENKINS-28022

2. Incremented version.
3. Fixed cb() which is not defined for current scenarios and was giving error in console by checking if it is defined